### PR TITLE
Clear existing user groups before assigning new one

### DIFF
--- a/authentication/models.py
+++ b/authentication/models.py
@@ -20,6 +20,9 @@ class User(AbstractUser):
 
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
+        #Clear any existing group before assigning new one so this works correctly on edition
+        self.groups.clear()
+        
         if self.role == self.CREATOR:
             group = Group.objects.get(name='creators')
             group.user_set.add(self)


### PR DESCRIPTION
Was reading your tutorial on openclassrooms and ended up noticing that group attribution doesn't delete previous group when we edit a user profile so I've decided to pull my solution here. May be It'll help someone out there. Thanks for the great content you've provided us.